### PR TITLE
feat!: parameterize Timestamped on clock source

### DIFF
--- a/src/Data/Tracer/Contrib.hs
+++ b/src/Data/Tracer/Contrib.hs
@@ -37,7 +37,8 @@ module Data.Tracer.Contrib
 
       -- * Timestamps
     , Timestamped (..)
-    , timestampTracer
+    , utcTimestampTracer
+    , monotonicTimestampTracer
 
       -- * Throttling
     , Throttled (..)
@@ -56,7 +57,11 @@ import Data.Tracer.Intercept (intercept)
 import Data.Tracer.LogFile (logFileTracer, logTracer)
 import Data.Tracer.ThreadSafe (newThreadSafeTracer)
 import Data.Tracer.Throttle (Throttled (..), throttleByFrequency)
-import Data.Tracer.Timestamp (Timestamped (..), timestampTracer)
+import Data.Tracer.Timestamp
+    ( Timestamped (..)
+    , monotonicTimestampTracer
+    , utcTimestampTracer
+    )
 import Data.Tracer.TraceWith
     ( contra
     , trace

--- a/src/Data/Tracer/Throttle.hs
+++ b/src/Data/Tracer/Throttle.hs
@@ -7,8 +7,13 @@ Description : Frequency-based event throttling
 Copyright   : (c) Paolo Veronelli, 2025
 License     : Apache-2.0
 
-Provides a tracer that throttles events based on frequency limits.
-Uses event timestamps for deterministic, testable behavior.
+Provides a tracer that throttles events based on frequency
+limits. Uses event timestamps for deterministic, testable
+behavior.
+
+The throttle is parameterized on the time type @t@ — pass
+a diff function to compute elapsed seconds between two
+timestamps.
 -}
 module Data.Tracer.Throttle
     ( Throttled (..)
@@ -19,17 +24,17 @@ import Control.Tracer (Tracer, traceWith)
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Time.Clock (UTCTime, diffUTCTime)
 import Data.Tracer.Internal (mkTracer)
 import Data.Tracer.Timestamp (Timestamped (..))
 
 {- | Result of throttling an event.
 
-When an event passes through the throttle, it includes a count of
-how many events were dropped since the last emission.
+When an event passes through the throttle, it includes
+a count of how many events were dropped since the last
+emission.
 -}
-data Throttled a = Throttled
-    { throttledEvent :: Timestamped a
+data Throttled t a = Throttled
+    { throttledEvent :: Timestamped t a
     -- ^ the event that passed through
     , throttledDropped :: Int
     -- ^ number of events dropped since last emission
@@ -37,52 +42,65 @@ data Throttled a = Throttled
     deriving (Show, Eq)
 
 -- | State for a single throttle category.
-data ThrottleState = ThrottleState
-    { lastEmitTime :: UTCTime
+data ThrottleState t = ThrottleState
+    { lastEmitTime :: t
     -- ^ when we last emitted for this category
     , droppedCount :: Int
     -- ^ events dropped since last emission
     }
 
-{- | Create a tracer that throttles events based on frequency limits.
+{- | Create a tracer that throttles events based on
+frequency limits.
 
-Each matcher function defines a throttle category. When a matcher
-returns @Just frequency@, events matching that category are limited
-to that frequency (in Hz, i.e., events per second).
+The first argument computes elapsed seconds between two
+timestamps. For example:
 
-Events that don't match any category pass through immediately.
-The first event in each category always passes through.
-Subsequent events within the throttle interval are dropped.
-When an event finally passes, it reports how many were dropped.
+* UTC: @\\t1 t2 -> realToFrac (diffUTCTime t2 t1)@
+* Monotonic: @\\t1 t2 -> fromIntegral (t2 - t1) / 1e9@
+
+Each matcher function defines a throttle category. When a
+matcher returns @Just frequency@, events matching that
+category are limited to that frequency (in Hz).
+
+Events that don't match any category pass through
+immediately. The first event in each category always
+passes through. Subsequent events within the throttle
+interval are dropped. When an event finally passes, it
+reports how many were dropped.
 
 @
 let matchErrors msg
-        | "error" \`isInfixOf\` msg = Just 1.0  -- max 1 per second
+        | "error" \`isInfixOf\` msg = Just 1.0
         | otherwise = Nothing
-tracer <- throttleByFrequency [matchErrors] downstream
+    diffSeconds t1 t2 =
+        realToFrac (diffUTCTime t2 t1)
+tracer <- throttleByFrequency diffSeconds [matchErrors] downstream
 @
 -}
 throttleByFrequency
-    :: [a -> Maybe Double]
-    -- ^ matchers returning frequency in Hz (events/second)
-    -> Tracer IO (Throttled a)
+    :: (t -> t -> Double)
+    -- ^ elapsed seconds between two timestamps
+    -> [a -> Maybe Double]
+    -- ^ matchers returning frequency in Hz
+    -> Tracer IO (Throttled t a)
     -- ^ downstream tracer
-    -> IO (Tracer IO (Timestamped a))
-throttleByFrequency matchers downstream = do
-    stateRef <- newIORef (Map.empty :: Map Int ThrottleState)
+    -> IO (Tracer IO (Timestamped t a))
+throttleByFrequency diffSeconds matchers downstream = do
+    stateRef <- newIORef (Map.empty :: Map Int (ThrottleState t))
     return $ mkTracer $ \event -> do
         let ts = timestampedTime event
         case findMatch matchers (timestampedEvent event) of
             Nothing ->
-                -- No matcher - pass through immediately
                 traceWith downstream $
-                    Throttled{throttledEvent = event, throttledDropped = 0}
+                    Throttled
+                        { throttledEvent = event
+                        , throttledDropped = 0
+                        }
             Just (categoryIdx, frequency) -> do
                 let interval = 1.0 / frequency
                 state <- readIORef stateRef
                 case Map.lookup categoryIdx state of
                     Nothing -> do
-                        -- First event in category - emit and record
                         modifyIORef' stateRef $
                             Map.insert
                                 categoryIdx
@@ -92,39 +110,54 @@ throttleByFrequency matchers downstream = do
                                     }
                         traceWith downstream $
                             Throttled
-                                { throttledEvent = event
+                                { throttledEvent =
+                                    event
                                 , throttledDropped = 0
                                 }
-                    Just ThrottleState{lastEmitTime, droppedCount} -> do
-                        let elapsed =
-                                realToFrac (diffUTCTime ts lastEmitTime)
-                                    :: Double
-                        if elapsed >= interval
-                            then do
-                                -- Interval passed - emit with drop count
-                                modifyIORef' stateRef $
-                                    Map.insert
-                                        categoryIdx
-                                        ThrottleState
-                                            { lastEmitTime = ts
-                                            , droppedCount = 0
+                    Just
+                        ThrottleState
+                            { lastEmitTime
+                            , droppedCount
+                            } -> do
+                            let elapsed =
+                                    diffSeconds
+                                        lastEmitTime
+                                        ts
+                            if elapsed >= interval
+                                then do
+                                    modifyIORef' stateRef $
+                                        Map.insert
+                                            categoryIdx
+                                            ThrottleState
+                                                { lastEmitTime =
+                                                    ts
+                                                , droppedCount =
+                                                    0
+                                                }
+                                    traceWith downstream $
+                                        Throttled
+                                            { throttledEvent =
+                                                event
+                                            , throttledDropped =
+                                                droppedCount
                                             }
-                                traceWith downstream $
-                                    Throttled
-                                        { throttledEvent = event
-                                        , throttledDropped = droppedCount
-                                        }
-                            else do
-                                -- Within interval - drop and count
-                                modifyIORef' stateRef $
-                                    Map.adjust
-                                        ( \s ->
-                                            s{droppedCount = droppedCount + 1}
-                                        )
-                                        categoryIdx
+                                else
+                                    modifyIORef' stateRef $
+                                        Map.adjust
+                                            ( \s ->
+                                                s
+                                                    { droppedCount =
+                                                        droppedCount
+                                                            + 1
+                                                    }
+                                            )
+                                            categoryIdx
 
 -- | Find the first matching category and its frequency.
-findMatch :: [a -> Maybe Double] -> a -> Maybe (Int, Double)
+findMatch
+    :: [a -> Maybe Double]
+    -> a
+    -> Maybe (Int, Double)
 findMatch matchers event = go 0 matchers
   where
     go _ [] = Nothing

--- a/src/Data/Tracer/Timestamp.hs
+++ b/src/Data/Tracer/Timestamp.hs
@@ -4,51 +4,81 @@ Description : Timestamped event wrapper and tracer
 Copyright   : (c) Paolo Veronelli, 2025
 License     : Apache-2.0
 
-Provides a wrapper to pair events with their timestamps, and a tracer
-transformer that automatically adds timestamps to events.
+Provides a wrapper to pair events with their timestamps,
+and tracer transformers that automatically add timestamps
+to events.
+
+Two clock sources are supported:
+
+* 'utcTimestampTracer' — wall-clock time via
+  'getCurrentTime'
+* 'monotonicTimestampTracer' — monotonic nanoseconds via
+  'getMonotonicTimeNSec' (no NTP jumps, microsecond
+  precision)
 -}
 module Data.Tracer.Timestamp
     ( Timestamped (..)
-    , timestampTracer
+    , utcTimestampTracer
+    , monotonicTimestampTracer
     ) where
 
 import Control.Tracer (Tracer, traceWith)
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import Data.Tracer.Internal (mkTracer)
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
 
 {- | A wrapper that pairs an event with its timestamp.
 
-This is useful for tracers that need to process events based on
-when they occurred, such as throttling or time-based filtering.
+The time type @t@ is determined by the clock source:
+
+* @'UTCTime'@ for wall-clock timestamps
+* @'Word64'@ (nanoseconds) for monotonic timestamps
 
 @
 event <- Timestamped \<$\> getCurrentTime \<*\> pure myEvent
 traceWith tracer event
 @
 -}
-data Timestamped a = Timestamped
-    { timestampedTime :: UTCTime
+data Timestamped t a = Timestamped
+    { timestampedTime :: t
     -- ^ when the event occurred
     , timestampedEvent :: a
     -- ^ the event payload
     }
     deriving (Show, Eq)
 
-{- | Wrap events with their current timestamp.
+{- | Wrap events with wall-clock timestamps.
 
-Takes a downstream tracer that expects timestamped events and returns
-a tracer that accepts raw events, automatically adding timestamps.
+Uses 'getCurrentTime' which has microsecond precision
+but may jump due to NTP adjustments.
 
 @
-downstream <- throttleByFrequency [matcher] baseTracer
-let tracer = timestampTracer downstream
-traceWith tracer "Hello"  -- automatically timestamped
+let tracer = utcTimestampTracer downstream
+traceWith tracer \"Hello\"
 @
-
-This is commonly composed with 'throttleByFrequency' which expects
-'Timestamped a' inputs for time-based throttling.
 -}
-timestampTracer :: Tracer IO (Timestamped a) -> Tracer IO a
-timestampTracer downstream = mkTracer $ \event -> do
+utcTimestampTracer
+    :: Tracer IO (Timestamped UTCTime a)
+    -> Tracer IO a
+utcTimestampTracer downstream = mkTracer $ \event -> do
     time <- getCurrentTime
+    traceWith downstream $ Timestamped time event
+
+{- | Wrap events with monotonic timestamps.
+
+Uses 'getMonotonicTimeNSec' which returns nanoseconds
+since an arbitrary epoch. Monotonically increasing,
+unaffected by NTP. Ideal for measuring durations.
+
+@
+let tracer = monotonicTimestampTracer downstream
+traceWith tracer \"Hello\"
+@
+-}
+monotonicTimestampTracer
+    :: Tracer IO (Timestamped Word64 a)
+    -> Tracer IO a
+monotonicTimestampTracer downstream = mkTracer $ \event -> do
+    time <- getMonotonicTimeNSec
     traceWith downstream $ Timestamped time event

--- a/test/Data/Tracer/CompositionSpec.hs
+++ b/test/Data/Tracer/CompositionSpec.hs
@@ -17,12 +17,22 @@ import Control.Monad (forM_, replicateM_)
 import Control.Tracer (Tracer, traceWith)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.List (isInfixOf)
-import Data.Time.Clock (UTCTime, addUTCTime)
+import Data.Time.Clock
+    ( UTCTime
+    , addUTCTime
+    , diffUTCTime
+    )
 import Data.Tracer.Intercept (intercept)
 import Data.Tracer.Internal (mkTracer)
 import Data.Tracer.ThreadSafe (newThreadSafeTracer)
-import Data.Tracer.Throttle (Throttled (..), throttleByFrequency)
-import Data.Tracer.Timestamp (Timestamped (..), timestampTracer)
+import Data.Tracer.Throttle
+    ( Throttled (..)
+    , throttleByFrequency
+    )
+import Data.Tracer.Timestamp
+    ( Timestamped (..)
+    , utcTimestampTracer
+    )
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
 -- | Create a tracer that collects events in a list (thread-safe append)
@@ -38,32 +48,42 @@ baseTime = read "2024-01-01 00:00:00 UTC"
 addSeconds :: Double -> UTCTime -> UTCTime
 addSeconds s = addUTCTime (realToFrac s)
 
+-- | Diff function for UTCTime
+diffSecs :: UTCTime -> UTCTime -> Double
+diffSecs t1 t2 = realToFrac (diffUTCTime t2 t1)
+
 -- | Create a Timestamped with a specific time
-mkTimestamped :: UTCTime -> a -> Timestamped a
-mkTimestamped t a = Timestamped{timestampedTime = t, timestampedEvent = a}
+mkTimestamped :: UTCTime -> a -> Timestamped UTCTime a
+mkTimestamped t a =
+    Timestamped
+        { timestampedTime = t
+        , timestampedEvent = a
+        }
 
 -- | Match errors by checking for "error" in the string
 matchError :: String -> Maybe String
 matchError s = if "error" `isInfixOf` s then Just s else Nothing
 
 -- | Extract events that had drops
-extractDrops :: Throttled String -> Maybe (Throttled String)
+extractDrops
+    :: Throttled UTCTime String
+    -> Maybe (Throttled UTCTime String)
 extractDrops t@Throttled{throttledDropped}
     | throttledDropped > 0 = Just t
     | otherwise = Nothing
 
 -- | Check if a Timestamped event is valid (non-empty event)
-hasValidTimestamp :: Timestamped String -> Bool
+hasValidTimestamp :: Timestamped UTCTime String -> Bool
 hasValidTimestamp ts = not (null (timestampedEvent ts))
 
 spec :: Spec
 spec = describe "Tracer Compositions" $ do
-    describe "timestampTracer + ThreadSafe" $ do
+    describe "utcTimestampTracer + ThreadSafe" $ do
         it "adds timestamps correctly under concurrent access" $ do
             ref <- newIORef []
             let baseTracer = collectTracer ref
-            throttled <- throttleByFrequency [] baseTracer
-            let timestamped = timestampTracer throttled
+            throttled <- throttleByFrequency diffSecs [] baseTracer
+            let timestamped = utcTimestampTracer throttled
             safe <- newThreadSafeTracer timestamped
 
             forConcurrently_ [1 :: Int .. 50] $ \i ->
@@ -78,7 +98,8 @@ spec = describe "Tracer Compositions" $ do
         it "throttles correctly under concurrent access" $ do
             ref <- newIORef []
             let matcher _ = Just 1.0 -- 1 Hz
-            throttled <- throttleByFrequency [matcher] (collectTracer ref)
+            throttled <-
+                throttleByFrequency diffSecs [matcher] (collectTracer ref)
             safe <- newThreadSafeTracer throttled
 
             -- All events have same timestamp, so all after first should drop
@@ -93,7 +114,8 @@ spec = describe "Tracer Compositions" $ do
         it "maintains correct drop counts with sequential timestamps" $ do
             ref <- newIORef []
             let matcher _ = Just 1.0 -- 1 Hz = 1 second interval
-            throttled <- throttleByFrequency [matcher] (collectTracer ref)
+            throttled <-
+                throttleByFrequency diffSecs [matcher] (collectTracer ref)
             safe <- newThreadSafeTracer throttled
 
             -- Send events: 0s, 0.1s, 0.2s, ..., 1.0s, 1.1s, ..., 2.0s
@@ -157,7 +179,8 @@ spec = describe "Tracer Compositions" $ do
                 interceptedLog = intercept errorTracer extractDrops logTracer'
 
             -- Throttle at 10 Hz (0.1s interval)
-            throttled <- throttleByFrequency [\_ -> Just 10.0] interceptedLog
+            throttled <-
+                throttleByFrequency diffSecs [\_ -> Just 10.0] interceptedLog
             safe <- newThreadSafeTracer throttled
 
             -- Send 100 events with 0.05s spacing (faster than throttle)
@@ -185,7 +208,8 @@ spec = describe "Tracer Compositions" $ do
                 -- Intercept events with drops before they reach logTracer
                 interceptedLog = intercept errorTracer extractDrops logTracer'
 
-            throttled <- throttleByFrequency [\_ -> Just 100.0] interceptedLog
+            throttled <-
+                throttleByFrequency diffSecs [\_ -> Just 100.0] interceptedLog
             safe <- newThreadSafeTracer throttled
 
             -- Concurrent access with varying timestamps

--- a/test/Data/Tracer/ThrottleSpec.hs
+++ b/test/Data/Tracer/ThrottleSpec.hs
@@ -4,9 +4,12 @@ module Data.Tracer.ThrottleSpec
 
 import Control.Tracer (Tracer, traceWith)
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
-import Data.Time.Clock (UTCTime, addUTCTime)
+import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime)
 import Data.Tracer.Internal (mkTracer)
-import Data.Tracer.Throttle (Throttled (..), throttleByFrequency)
+import Data.Tracer.Throttle
+    ( Throttled (..)
+    , throttleByFrequency
+    )
 import Data.Tracer.Timestamp (Timestamped (..))
 import Test.Hspec (Spec, describe, it, shouldBe)
 
@@ -15,76 +18,173 @@ collectTracer :: IORef [a] -> Tracer IO a
 collectTracer ref = mkTracer $ \a -> modifyIORef' ref (a :)
 
 -- | Helper to create a Timestamped with a specific time
-mkTimestamped :: UTCTime -> a -> Timestamped a
-mkTimestamped t a = Timestamped{timestampedTime = t, timestampedEvent = a}
+mkTimestamped :: t -> a -> Timestamped t a
+mkTimestamped t a =
+    Timestamped
+        { timestampedTime = t
+        , timestampedEvent = a
+        }
+
+-- | Diff function for UTCTime
+diffSeconds :: UTCTime -> UTCTime -> Double
+diffSeconds t1 t2 = realToFrac (diffUTCTime t2 t1)
 
 -- | Base time for tests
 baseTime :: UTCTime
 baseTime = read "2024-01-01 00:00:00 UTC"
 
 -- | Add seconds to base time
-addSeconds :: Double -> UTCTime -> UTCTime
-addSeconds s = addUTCTime (realToFrac s)
+addSecs :: Double -> UTCTime -> UTCTime
+addSecs s = addUTCTime (realToFrac s)
 
 spec :: Spec
 spec = do
     describe "throttleByFrequency" $ do
-        it "passes through non-matching events immediately" $ do
-            ref <- newIORef []
-            tracer <- throttleByFrequency [] (collectTracer ref)
-            traceWith tracer (mkTimestamped baseTime "event1")
-            traceWith tracer (mkTimestamped baseTime "event2")
-            results <- reverse <$> readIORef ref
-            length results `shouldBe` 2
-            map throttledDropped results `shouldBe` [0, 0]
+        it "passes through non-matching events immediately" $
+            do
+                ref <- newIORef []
+                tracer <-
+                    throttleByFrequency
+                        diffSeconds
+                        []
+                        (collectTracer ref)
+                traceWith
+                    tracer
+                    (mkTimestamped baseTime "event1")
+                traceWith
+                    tracer
+                    (mkTimestamped baseTime "event2")
+                results <- reverse <$> readIORef ref
+                length results `shouldBe` 2
+                map throttledDropped results
+                    `shouldBe` [0, 0]
 
-        it "emits first matching event immediately" $ do
-            ref <- newIORef []
-            let matcher _ = Just 1.0 -- 1 Hz = 1 event per second
-            tracer <- throttleByFrequency [matcher] (collectTracer ref)
-            traceWith tracer (mkTimestamped baseTime "event1")
-            results <- readIORef ref
-            case results of
-                [r] -> throttledDropped r `shouldBe` 0
-                _ -> fail "expected exactly one result"
+        it "emits first matching event immediately" $
+            do
+                ref <- newIORef []
+                let matcher _ = Just 1.0
+                tracer <-
+                    throttleByFrequency
+                        diffSeconds
+                        [matcher]
+                        (collectTracer ref)
+                traceWith
+                    tracer
+                    (mkTimestamped baseTime "event1")
+                results <- readIORef ref
+                case results of
+                    [r] ->
+                        throttledDropped r `shouldBe` 0
+                    _ ->
+                        fail "expected exactly one result"
 
-        it "drops events within throttle interval" $ do
-            ref <- newIORef []
-            let matcher _ = Just 1.0 -- 1 Hz = 1 event per second
-            tracer <- throttleByFrequency [matcher] (collectTracer ref)
-            traceWith tracer (mkTimestamped baseTime "event1")
-            traceWith tracer (mkTimestamped (addSeconds 0.5 baseTime) "event2")
-            traceWith tracer (mkTimestamped (addSeconds 0.9 baseTime) "event3")
-            results <- readIORef ref
-            length results `shouldBe` 1 -- only first event emitted
-        it "reports dropped count when interval passes" $ do
-            ref <- newIORef []
-            let matcher _ = Just 1.0 -- 1 Hz
-            tracer <- throttleByFrequency [matcher] (collectTracer ref)
-            traceWith tracer (mkTimestamped baseTime "event1")
-            traceWith tracer (mkTimestamped (addSeconds 0.3 baseTime) "event2")
-            traceWith tracer (mkTimestamped (addSeconds 0.6 baseTime) "event3")
-            traceWith tracer (mkTimestamped (addSeconds 1.1 baseTime) "event4")
-            results <- reverse <$> readIORef ref
-            length results `shouldBe` 2
-            map throttledDropped results `shouldBe` [0, 2]
-            map (timestampedEvent . throttledEvent) results
-                `shouldBe` ["event1", "event4"]
+        it "drops events within throttle interval" $
+            do
+                ref <- newIORef []
+                let matcher _ = Just 1.0
+                tracer <-
+                    throttleByFrequency
+                        diffSeconds
+                        [matcher]
+                        (collectTracer ref)
+                traceWith
+                    tracer
+                    (mkTimestamped baseTime "event1")
+                traceWith
+                    tracer
+                    ( mkTimestamped
+                        (addSecs 0.5 baseTime)
+                        "event2"
+                    )
+                traceWith
+                    tracer
+                    ( mkTimestamped
+                        (addSecs 0.9 baseTime)
+                        "event3"
+                    )
+                results <- readIORef ref
+                length results `shouldBe` 1
 
-        it "handles multiple matcher categories independently" $ do
-            ref <- newIORef []
-            let matcherA "A" = Just 1.0
-                matcherA _ = Nothing
-                matcherB "B" = Just 2.0 -- 2 Hz = 0.5s interval
-                matcherB _ = Nothing
-            tracer <-
-                throttleByFrequency [matcherA, matcherB] (collectTracer ref)
-            traceWith tracer (mkTimestamped baseTime "A")
-            traceWith tracer (mkTimestamped baseTime "B")
-            traceWith tracer (mkTimestamped (addSeconds 0.3 baseTime) "A")
-            traceWith tracer (mkTimestamped (addSeconds 0.3 baseTime) "B")
-            traceWith tracer (mkTimestamped (addSeconds 0.6 baseTime) "B")
-            results <- reverse <$> readIORef ref
-            length results `shouldBe` 3 -- A(0s), B(0s), B(0.6s)
-            map (timestampedEvent . throttledEvent) results
-                `shouldBe` ["A", "B", "B"]
+        it "reports dropped count when interval passes" $
+            do
+                ref <- newIORef []
+                let matcher _ = Just 1.0
+                tracer <-
+                    throttleByFrequency
+                        diffSeconds
+                        [matcher]
+                        (collectTracer ref)
+                traceWith
+                    tracer
+                    (mkTimestamped baseTime "event1")
+                traceWith
+                    tracer
+                    ( mkTimestamped
+                        (addSecs 0.3 baseTime)
+                        "event2"
+                    )
+                traceWith
+                    tracer
+                    ( mkTimestamped
+                        (addSecs 0.6 baseTime)
+                        "event3"
+                    )
+                traceWith
+                    tracer
+                    ( mkTimestamped
+                        (addSecs 1.1 baseTime)
+                        "event4"
+                    )
+                results <- reverse <$> readIORef ref
+                length results `shouldBe` 2
+                map throttledDropped results
+                    `shouldBe` [0, 2]
+                map
+                    (timestampedEvent . throttledEvent)
+                    results
+                    `shouldBe` ["event1", "event4"]
+
+        it
+            "handles multiple matcher categories \
+            \independently"
+            $ do
+                ref <- newIORef []
+                let matcherA "A" = Just 1.0
+                    matcherA _ = Nothing
+                    matcherB "B" = Just 2.0
+                    matcherB _ = Nothing
+                tracer <-
+                    throttleByFrequency
+                        diffSeconds
+                        [matcherA, matcherB]
+                        (collectTracer ref)
+                traceWith
+                    tracer
+                    (mkTimestamped baseTime "A")
+                traceWith
+                    tracer
+                    (mkTimestamped baseTime "B")
+                traceWith
+                    tracer
+                    ( mkTimestamped
+                        (addSecs 0.3 baseTime)
+                        "A"
+                    )
+                traceWith
+                    tracer
+                    ( mkTimestamped
+                        (addSecs 0.3 baseTime)
+                        "B"
+                    )
+                traceWith
+                    tracer
+                    ( mkTimestamped
+                        (addSecs 0.6 baseTime)
+                        "B"
+                    )
+                results <- reverse <$> readIORef ref
+                length results `shouldBe` 3
+                map
+                    (timestampedEvent . throttledEvent)
+                    results
+                    `shouldBe` ["A", "B", "B"]

--- a/test/Data/Tracer/TimestampSpec.hs
+++ b/test/Data/Tracer/TimestampSpec.hs
@@ -4,7 +4,12 @@ import Control.Tracer (traceWith)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Time.Clock (getCurrentTime)
 import Data.Tracer.Internal (mkTracer)
-import Data.Tracer.Timestamp (Timestamped (..), timestampTracer)
+import Data.Tracer.Timestamp
+    ( Timestamped (..)
+    , monotonicTimestampTracer
+    , utcTimestampTracer
+    )
+import GHC.Clock (getMonotonicTimeNSec)
 import Test.Hspec
     ( Spec
     , describe
@@ -20,76 +25,149 @@ spec = do
         it "stores time and event" $ do
             now <- getCurrentTime
             let ts = Timestamped now "test"
-            timestampedTime ts `shouldSatisfy` (== now)
+            timestampedTime ts
+                `shouldSatisfy` (== now)
             timestampedEvent ts `shouldBe` "test"
 
-    describe "timestampTracer" $ do
+    describe "utcTimestampTracer" $ do
         it "wraps events with timestamps" $ do
             ref <- newIORef Nothing
-            let downstream = mkTracer $ writeIORef ref . Just
-                tracer = timestampTracer downstream
+            let downstream =
+                    mkTracer $ writeIORef ref . Just
+                tracer = utcTimestampTracer downstream
             traceWith tracer "test message"
             result <- readIORef ref
             case result of
-                Nothing -> expectationFailure "No event received"
+                Nothing ->
+                    expectationFailure
+                        "No event received"
                 Just (Timestamped _ event) ->
                     event `shouldBe` "test message"
 
         it "adds current time to events" $ do
             ref <- newIORef Nothing
             before <- getCurrentTime
-            let downstream = mkTracer $ writeIORef ref . Just
-                tracer = timestampTracer downstream
+            let downstream =
+                    mkTracer $ writeIORef ref . Just
+                tracer = utcTimestampTracer downstream
             traceWith tracer "test"
             after <- getCurrentTime
             result <- readIORef ref
             case result of
-                Nothing -> expectationFailure "No event received"
+                Nothing ->
+                    expectationFailure
+                        "No event received"
                 Just (Timestamped time _) -> do
                     time `shouldSatisfy` (>= before)
                     time `shouldSatisfy` (<= after)
 
         it "preserves event content unchanged" $ do
             ref <- newIORef Nothing
-            let downstream = mkTracer $ writeIORef ref . Just
-                tracer = timestampTracer downstream
-                testData = ("key", [1, 2, 3 :: Int], True)
+            let downstream =
+                    mkTracer $ writeIORef ref . Just
+                tracer = utcTimestampTracer downstream
+                testData =
+                    ("key", [1, 2, 3 :: Int], True)
             traceWith tracer testData
             result <- readIORef ref
             case result of
-                Nothing -> expectationFailure "No event received"
+                Nothing ->
+                    expectationFailure
+                        "No event received"
                 Just (Timestamped _ event) ->
                     event `shouldBe` testData
 
         it "works with different event types" $ do
             intRef <- newIORef Nothing
-            let intDownstream = mkTracer $ writeIORef intRef . Just
-                intTracer = timestampTracer intDownstream
+            let intDownstream =
+                    mkTracer $ writeIORef intRef . Just
+                intTracer =
+                    utcTimestampTracer intDownstream
             traceWith intTracer (42 :: Int)
             intResult <- readIORef intRef
-            fmap timestampedEvent intResult `shouldBe` Just 42
+            fmap timestampedEvent intResult
+                `shouldBe` Just 42
 
             listRef <- newIORef Nothing
-            let listDownstream = mkTracer $ writeIORef listRef . Just
-                listTracer = timestampTracer listDownstream
+            let listDownstream =
+                    mkTracer $
+                        writeIORef listRef . Just
+                listTracer =
+                    utcTimestampTracer listDownstream
             traceWith listTracer [1, 2, 3 :: Int]
             listResult <- readIORef listRef
-            fmap timestampedEvent listResult `shouldBe` Just [1, 2, 3]
+            fmap timestampedEvent listResult
+                `shouldBe` Just [1, 2, 3]
 
-        it "assigns non-decreasing timestamps to sequential events" $ do
+        it "assigns non-decreasing timestamps" $ do
             ref <- newIORef []
             let downstream = mkTracer $ \ts -> do
                     v <- readIORef ref
                     writeIORef ref (ts : v)
-                tracer = timestampTracer downstream
+                tracer = utcTimestampTracer downstream
             traceWith tracer "first"
             traceWith tracer "second"
             traceWith tracer "third"
             results <- reverse <$> readIORef ref
             length results `shouldBe` 3
             let times = map timestampedTime results
-            -- Times should be non-decreasing
+            times `shouldSatisfy` isNonDecreasing
+
+    describe "monotonicTimestampTracer" $ do
+        it "wraps events with nanosecond timestamps" $
+            do
+                ref <- newIORef Nothing
+                let downstream =
+                        mkTracer $ writeIORef ref . Just
+                    tracer =
+                        monotonicTimestampTracer
+                            downstream
+                traceWith tracer "test message"
+                result <- readIORef ref
+                case result of
+                    Nothing ->
+                        expectationFailure
+                            "No event received"
+                    Just (Timestamped _ event) ->
+                        event `shouldBe` "test message"
+
+        it "produces timestamps near current time" $
+            do
+                ref <- newIORef Nothing
+                before <- getMonotonicTimeNSec
+                let downstream =
+                        mkTracer $ writeIORef ref . Just
+                    tracer =
+                        monotonicTimestampTracer
+                            downstream
+                traceWith tracer "test"
+                after <- getMonotonicTimeNSec
+                result <- readIORef ref
+                case result of
+                    Nothing ->
+                        expectationFailure
+                            "No event received"
+                    Just (Timestamped time _) -> do
+                        time
+                            `shouldSatisfy` (>= before)
+                        time
+                            `shouldSatisfy` (<= after)
+
+        it "assigns non-decreasing timestamps" $ do
+            ref <- newIORef []
+            let downstream = mkTracer $ \ts -> do
+                    v <- readIORef ref
+                    writeIORef ref (ts : v)
+                tracer =
+                    monotonicTimestampTracer downstream
+            traceWith tracer "first"
+            traceWith tracer "second"
+            traceWith tracer "third"
+            results <- reverse <$> readIORef ref
+            length results `shouldBe` 3
+            let times = map timestampedTime results
             times `shouldSatisfy` isNonDecreasing
   where
     isNonDecreasing :: (Ord a) => [a] -> Bool
-    isNonDecreasing xs = and $ zipWith (<=) xs (drop 1 xs)
+    isNonDecreasing xs =
+        and $ zipWith (<=) xs (drop 1 xs)


### PR DESCRIPTION
## Summary
- `Timestamped t a` parameterized on time type
- `utcTimestampTracer` + `monotonicTimestampTracer`
- `throttleByFrequency` takes diff function param
- All 41 tests pass

Closes #10