### PR TITLE
feat!: add Timing GADT singleton for clock source selection

### DIFF
--- a/src/Data/Tracer/Contrib.hs
+++ b/src/Data/Tracer/Contrib.hs
@@ -41,6 +41,7 @@ module Data.Tracer.Contrib
     , monotonicTimestampTracer
 
       -- * Duration Measurement
+    , Timing (..)
     , measureDuration
 
       -- * Throttling
@@ -58,7 +59,7 @@ import Control.Tracer (Tracer, traceWith)
 
 import Data.Tracer.Intercept (intercept)
 import Data.Tracer.LogFile (logFileTracer, logTracer)
-import Data.Tracer.Measure (measureDuration)
+import Data.Tracer.Measure (Timing (..), measureDuration)
 import Data.Tracer.ThreadSafe (newThreadSafeTracer)
 import Data.Tracer.Throttle (Throttled (..), throttleByFrequency)
 import Data.Tracer.Timestamp

--- a/src/Data/Tracer/Measure.hs
+++ b/src/Data/Tracer/Measure.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 {- |
 Module      : Data.Tracer.Measure
 Description : Duration measurement between paired events
@@ -5,34 +7,77 @@ Copyright   : (c) Paolo Veronelli, 2025
 License     : Apache-2.0
 
 A tracer transformer that intercepts paired start\/end events,
-measures the elapsed time between them using a monotonic clock,
-and emits a single composed event carrying the duration.
+measures the elapsed time between them, and emits a single
+composed event carrying the duration in seconds.
 
 Non-matching events pass through unchanged. The start event
 is swallowed, the end event is replaced by the composed
 measurement. This keeps the producer free from 'MonadIO'
 — all timing happens in the 'IO' tracer pipeline.
+
+The 'Timing' singleton selects the clock source. Pattern
+matching on it provides both the clock read and the diff
+function, so users only choose the variant — everything
+else follows.
 -}
 module Data.Tracer.Measure
-    ( measureDuration
+    ( Timing (..)
+    , measureDuration
     ) where
 
 import Control.Tracer (Tracer, traceWith)
 import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Time.Clock
+    ( UTCTime
+    , diffUTCTime
+    , getCurrentTime
+    , nominalDiffTimeToSeconds
+    )
 import Data.Tracer.Internal (mkTracer)
 import Data.Word (Word64)
 import GHC.Clock (getMonotonicTimeNSec)
 
+{- | Clock source for duration measurement.
+
+Pattern matching on a 'Timing' value determines the
+timestamp type @t@, the clock read action, and the diff
+function that converts two timestamps to seconds.
+-}
+data Timing t where
+    {- | Monotonic clock. Nanosecond precision, unaffected
+    by NTP adjustments. Ideal for measuring durations.
+    -}
+    Monotonic :: Timing Word64
+    {- | Wall clock via 'getCurrentTime'. Microsecond
+    precision, subject to NTP jumps.
+    -}
+    WallClock :: Timing UTCTime
+
+-- | Read the clock for a given 'Timing'.
+readClock :: Timing t -> IO t
+readClock Monotonic = getMonotonicTimeNSec
+readClock WallClock = getCurrentTime
+
+-- | Compute elapsed seconds between two timestamps.
+diffSeconds :: Timing t -> t -> t -> Double
+diffSeconds Monotonic t0 t1 =
+    fromIntegral (t1 - t0) / 1e9
+diffSeconds WallClock t0 t1 =
+    realToFrac $
+        nominalDiffTimeToSeconds $
+            diffUTCTime t1 t0
+
 {- | Create a tracer that measures duration between paired
 events.
 
-Given two selectors and a composer, this transformer:
+Given a clock source, two selectors, and a composer, this
+transformer:
 
-1. When the start selector matches: records the monotonic
-   timestamp and the extracted context, swallows the event.
-2. When the end selector matches: computes elapsed
-   nanoseconds since the start, emits the composed event,
-   clears the pending state.
+1. When the start selector matches: records the timestamp
+   and the extracted context, swallows the event.
+2. When the end selector matches: computes elapsed seconds
+   since the start, emits the composed event, clears the
+   pending state.
 3. All other events pass through unchanged.
 
 If an end event arrives without a preceding start, it is
@@ -43,34 +88,36 @@ without an end, the second overwrites the first.
 data AppTrace
     = PhaseStart String
     | PhaseEnd String
-    | PhaseDuration String String Word64
+    | PhaseDuration String String Double
     | OtherTrace String
 
-tracer <- measureDuration
+tracer <- measureDuration Monotonic
     (\\case PhaseStart s -> Just s; _ -> Nothing)
     (\\case PhaseEnd s -> Just s; _ -> Nothing)
-    (\\startCtx endCtx ns -> PhaseDuration startCtx endCtx ns)
+    (\\startCtx endCtx secs -> PhaseDuration startCtx endCtx secs)
     downstream
 @
 -}
 measureDuration
-    :: (a -> Maybe b)
+    :: Timing t
+    -- ^ clock source
+    -> (a -> Maybe b)
     -- ^ select start event, extract context
     -> (a -> Maybe c)
     -- ^ select end event, extract context
-    -> (b -> c -> Word64 -> a)
-    -- ^ compose measurement (start, end, nanoseconds)
+    -> (b -> c -> Double -> a)
+    -- ^ compose measurement (start, end, seconds)
     -> Tracer IO a
     -- ^ downstream tracer
     -> IO (Tracer IO a)
     -- ^ stateful tracer
-measureDuration selectStart selectEnd compose downstream =
+measureDuration timing selectStart selectEnd compose downstream =
     do
         ref <- newIORef Nothing
         pure $ mkTracer $ \event ->
             case selectStart event of
                 Just ctx -> do
-                    t <- getMonotonicTimeNSec
+                    t <- readClock timing
                     writeIORef ref (Just (t, ctx))
                 Nothing -> case selectEnd event of
                     Just endCtx -> do
@@ -80,14 +127,16 @@ measureDuration selectStart selectEnd compose downstream =
                                 traceWith downstream event
                             Just (startTime, startCtx) -> do
                                 endTime <-
-                                    getMonotonicTimeNSec
+                                    readClock timing
                                 writeIORef ref Nothing
                                 traceWith downstream $
                                     compose
                                         startCtx
                                         endCtx
-                                        ( endTime
-                                            - startTime
+                                        ( diffSeconds
+                                            timing
+                                            startTime
+                                            endTime
                                         )
                     Nothing ->
                         traceWith downstream event

--- a/test/Data/Tracer/MeasureSpec.hs
+++ b/test/Data/Tracer/MeasureSpec.hs
@@ -7,8 +7,7 @@ import Data.IORef
     , writeIORef
     )
 import Data.Tracer.Internal (mkTracer)
-import Data.Tracer.Measure (measureDuration)
-import Data.Word (Word64)
+import Data.Tracer.Measure (Timing (..), measureDuration)
 import Test.Hspec
     ( Spec
     , describe
@@ -20,7 +19,7 @@ import Test.Hspec
 data Event
     = Start String
     | End String
-    | Duration String String Word64
+    | Duration String String Double
     | Other String
     deriving (Show, Eq)
 
@@ -32,7 +31,7 @@ selectEnd :: Event -> Maybe String
 selectEnd (End s) = Just s
 selectEnd _ = Nothing
 
-compose :: String -> String -> Word64 -> Event
+compose :: String -> String -> Double -> Event
 compose = Duration
 
 collector :: IO (Event -> IO (), IO [Event])
@@ -52,6 +51,7 @@ spec = do
                 let downstream = mkTracer push
                 tracer <-
                     measureDuration
+                        Monotonic
                         selectStart
                         selectEnd
                         compose
@@ -61,10 +61,10 @@ spec = do
                 events <- getEvents
                 length events `shouldBe` 1
                 case events of
-                    [Duration s e ns] -> do
+                    [Duration s e secs] -> do
                         s `shouldBe` "a"
                         e `shouldBe` "b"
-                        ns `shouldSatisfy` (>= 0)
+                        secs `shouldSatisfy` (>= 0)
                     _ ->
                         error "unexpected events"
 
@@ -73,6 +73,7 @@ spec = do
             let downstream = mkTracer push
             tracer <-
                 measureDuration
+                    Monotonic
                     selectStart
                     selectEnd
                     compose
@@ -90,6 +91,7 @@ spec = do
             let downstream = mkTracer push
             tracer <-
                 measureDuration
+                    Monotonic
                     selectStart
                     selectEnd
                     compose
@@ -103,6 +105,7 @@ spec = do
             let downstream = mkTracer push
             tracer <-
                 measureDuration
+                    Monotonic
                     selectStart
                     selectEnd
                     compose
@@ -112,8 +115,8 @@ spec = do
             traceWith tracer (End "y")
             events <- getEvents
             case events of
-                [Duration _ _ ns] ->
-                    ns `shouldSatisfy` (>= 0)
+                [Duration _ _ secs] ->
+                    secs `shouldSatisfy` (>= 0)
                 _ -> error "unexpected events"
 
         it "interleaves with other events" $ do
@@ -121,6 +124,7 @@ spec = do
             let downstream = mkTracer push
             tracer <-
                 measureDuration
+                    Monotonic
                     selectStart
                     selectEnd
                     compose
@@ -147,6 +151,7 @@ spec = do
             let downstream = mkTracer push
             tracer <-
                 measureDuration
+                    Monotonic
                     selectStart
                     selectEnd
                     compose
@@ -158,4 +163,24 @@ spec = do
             case events of
                 [Duration s _ _] ->
                     s `shouldBe` "second"
+                _ -> error "unexpected events"
+
+        it "works with WallClock timing" $ do
+            (push, getEvents) <- collector
+            let downstream = mkTracer push
+            tracer <-
+                measureDuration
+                    WallClock
+                    selectStart
+                    selectEnd
+                    compose
+                    downstream
+            traceWith tracer (Start "w")
+            traceWith tracer (End "c")
+            events <- getEvents
+            case events of
+                [Duration s e secs] -> do
+                    s `shouldBe` "w"
+                    e `shouldBe` "c"
+                    secs `shouldSatisfy` (>= 0)
                 _ -> error "unexpected events"


### PR DESCRIPTION
## Summary

- Add `Timing` GADT with `Monotonic` and `WallClock` constructors
- `measureDuration` now takes a `Timing t` parameter — pattern matching provides both clock read and diff-to-seconds
- Duration reported as `Double` seconds instead of `Word64` nanoseconds
- Re-export `Timing(..)` from `Data.Tracer.Contrib`

## Test plan

- [x] All existing tests updated to pass `Monotonic`
- [x] New test for `WallClock` timing
- [x] 48 tests pass, CI green