### PR TITLE
feat: add Foldl.Extra and Prometheus text format modules

### DIFF
--- a/contra-tracer-contrib.cabal
+++ b/contra-tracer-contrib.cabal
@@ -46,9 +46,11 @@ library
   exposed-modules:
     Data.Tracer.Contrib
     Data.Tracer.Fold
+    Data.Tracer.Foldl.Extra
     Data.Tracer.Intercept
     Data.Tracer.LogFile
     Data.Tracer.Measure
+    Data.Tracer.Prometheus
     Data.Tracer.Share
     Data.Tracer.ThreadSafe
     Data.Tracer.Throttle
@@ -61,6 +63,7 @@ library
     , containers     >=0.6  && <0.8
     , contra-tracer  >=0.1  && <0.3
     , foldl          >=1.4  && <1.5
+    , text           >=1.2  && <2.2
     , time           >=1.9  && <1.15
 
   hs-source-dirs:   src
@@ -76,9 +79,11 @@ test-suite unit-tests
   other-modules:
     Data.Tracer.CompositionSpec
     Data.Tracer.FoldSpec
+    Data.Tracer.Foldl.ExtraSpec
     Data.Tracer.InterceptSpec
     Data.Tracer.LogFileSpec
     Data.Tracer.MeasureSpec
+    Data.Tracer.PrometheusSpec
     Data.Tracer.ShareSpec
     Data.Tracer.ThreadSafeSpec
     Data.Tracer.ThrottleSpec
@@ -97,6 +102,7 @@ test-suite unit-tests
     , hspec
     , QuickCheck
     , temporary
+    , text
     , time
 
   hs-source-dirs:     test

--- a/src/Data/Tracer/Foldl/Extra.hs
+++ b/src/Data/Tracer/Foldl/Extra.hs
@@ -1,0 +1,120 @@
+{- |
+Module      : Data.Tracer.Foldl.Extra
+Description : Generic fold utilities for metrics collection
+Copyright   : (c) Paolo Veronelli, 2025
+License     : Apache-2.0
+
+Provides utility folds for calculating rolling statistics
+over event streams. These are designed for use with
+'Data.Tracer.Fold.foldTracer' to build metrics pipelines.
+
+@
+import Data.Tracer.Foldl.Extra (speedoMeter, averageOverWindow)
+
+utxoSpeedFold :: Fold (Timestamped UTCTime MetricsEvent) Double
+utxoSpeedFold =
+    lmap timedAsTuple
+        $ handles (aside _UTxOChangeEvent)
+        $ lmap fst
+        $ speedoMeter 1000
+@
+-}
+module Data.Tracer.Foldl.Extra
+    ( speedoMeter
+    , valueSpeedoMeter
+    , averageOverWindow
+    ) where
+
+import Control.Foldl (Fold (..))
+import Data.Time (UTCTime, diffUTCTime)
+import Data.Word (Word64)
+
+{- | Track the speed of events over a sliding window.
+
+Counts events in windows of @n@ and measures the time
+between the first and last event in each window, returning
+events per second. Returns 0 until the first full window
+completes.
+-}
+speedoMeter :: Int -> Fold UTCTime Double
+speedoMeter window = Fold count Nothing getSpeed
+  where
+    getSpeed Nothing = 0
+    getSpeed (Just (Nothing, _, _)) = 0
+    getSpeed (Just (Just (startTime, endTime, cnt), _, _)) =
+        fromIntegral cnt
+            / realToFrac (diffUTCTime endTime startTime)
+    count acc time = case acc of
+        Nothing -> Just (Nothing, time, 0)
+        Just (speed, startTime, cnt)
+            | cnt < window ->
+                Just (speed, startTime, cnt + 1)
+            | otherwise ->
+                Just
+                    ( Just (startTime, time, cnt)
+                    , time
+                    , 0
+                    )
+
+{- | Track the rate of change of a value over a sliding
+window.
+
+Unlike 'speedoMeter' which counts events per second, this
+measures the rate at which a numeric value changes per
+second.
+-}
+valueSpeedoMeter :: Int -> Fold (UTCTime, Word64) Double
+valueSpeedoMeter window = Fold step Nothing getSpeed
+  where
+    getSpeed Nothing = 0
+    getSpeed (Just (Nothing, _, _, _)) = 0
+    getSpeed
+        ( Just
+                ( Just
+                        ( startTime
+                            , startVal
+                            , endTime
+                            , endVal
+                            )
+                    , _
+                    , _
+                    , _
+                    )
+            ) =
+            let dt =
+                    realToFrac (diffUTCTime endTime startTime)
+                dv =
+                    fromIntegral endVal
+                        - fromIntegral startVal
+                        :: Double
+            in  if dt > 0 then dv / dt else 0
+    step acc (time, val) = case acc of
+        Nothing ->
+            Just (Nothing, time, val, 0 :: Int)
+        Just (speed, startTime, startVal, cnt)
+            | cnt < window ->
+                Just
+                    (speed, startTime, startVal, cnt + 1)
+            | otherwise ->
+                Just
+                    ( Just
+                        (startTime, startVal, time, val)
+                    , time
+                    , val
+                    , 0
+                    )
+
+{- | Calculate average over a rolling window.
+
+Keeps the last @window@ values and computes their average.
+Returns 0 if no values have been seen.
+-}
+averageOverWindow :: (Fractional a) => Int -> Fold a a
+averageOverWindow window = Fold step [] getAverage
+  where
+    step xs x = take window (x : xs)
+    getAverage xs =
+        let l = length xs
+        in  if l == 0
+                then 0
+                else sum xs / fromIntegral l

--- a/src/Data/Tracer/Prometheus.hs
+++ b/src/Data/Tracer/Prometheus.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Data.Tracer.Prometheus
+Description : Prometheus text exposition format helpers
+Copyright   : (c) Paolo Veronelli, 2025
+License     : Apache-2.0
+
+Helpers for rendering metrics in Prometheus text exposition
+format. Each metric is rendered as a HELP line, a TYPE line,
+and a value line, following the
+<https://prometheus.io/docs/instrumenting/exposition_formats/ Prometheus specification>.
+
+@
+renderMyMetrics :: Text -> MyMetrics -> Text
+renderMyMetrics prefix m =
+    renderPrometheusLines
+        [ gauge prefix "queue_length"
+            "Average queue length" (queueLen m)
+        , counter prefix "blocks_total"
+            "Total blocks processed"
+            (fromIntegral $ blockCount m)
+        ]
+@
+-}
+module Data.Tracer.Prometheus
+    ( gauge
+    , counter
+    , renderPrometheusLines
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+{- | Render a Prometheus gauge metric.
+
+A gauge is a metric that can go up and down (e.g. queue
+length, current speed).
+-}
+gauge
+    :: Text
+    -- ^ metric prefix (e.g. @\"myapp\"@)
+    -> Text
+    -- ^ metric name (e.g. @\"queue_length\"@)
+    -> Text
+    -- ^ help description
+    -> Double
+    -- ^ current value
+    -> [Text]
+gauge = metric "gauge"
+
+{- | Render a Prometheus counter metric.
+
+A counter is a metric that only goes up (e.g. total
+requests, cumulative duration).
+-}
+counter
+    :: Text
+    -- ^ metric prefix
+    -> Text
+    -- ^ metric name
+    -> Text
+    -- ^ help description
+    -> Double
+    -- ^ current value
+    -> [Text]
+counter = metric "counter"
+
+{- | Concatenate rendered metric blocks into a single
+Prometheus exposition text.
+-}
+renderPrometheusLines :: [[Text]] -> Text
+renderPrometheusLines = Text.unlines . concat
+
+-- internal
+
+metric :: Text -> Text -> Text -> Text -> Double -> [Text]
+metric typ prefix name help val =
+    [ "# HELP "
+        <> prefix
+        <> "_"
+        <> name
+        <> " "
+        <> help
+    , "# TYPE "
+        <> prefix
+        <> "_"
+        <> name
+        <> " "
+        <> typ
+    , prefix <> "_" <> name <> " " <> showDouble val
+    ]
+
+showDouble :: Double -> Text
+showDouble v =
+    let s = Text.pack $ show v
+    in  if Text.isSuffixOf ".0" s
+            then Text.dropEnd 2 s
+            else s

--- a/test/Data/Tracer/Foldl/ExtraSpec.hs
+++ b/test/Data/Tracer/Foldl/ExtraSpec.hs
@@ -1,0 +1,87 @@
+module Data.Tracer.Foldl.ExtraSpec (spec) where
+
+import Control.Foldl (Fold, fold)
+import Data.Time
+    ( UTCTime (..)
+    , addUTCTime
+    , fromGregorian
+    )
+import Data.Tracer.Foldl.Extra
+    ( averageOverWindow
+    , speedoMeter
+    , valueSpeedoMeter
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+epoch :: UTCTime
+epoch =
+    UTCTime (fromGregorian 2025 1 1) 0
+
+-- | Generate timestamps 1 second apart
+timestamps :: Int -> [UTCTime]
+timestamps n =
+    [ addUTCTime (fromIntegral i) epoch
+    | i <- [0 .. n - 1]
+    ]
+
+applyFold :: Fold a b -> [a] -> b
+applyFold = fold
+
+spec :: Spec
+spec = describe "Data.Tracer.Foldl.Extra" $ do
+    describe "averageOverWindow" $ do
+        it "returns 0 with no input" $ do
+            applyFold (averageOverWindow 10) ([] :: [Double])
+                `shouldBe` 0
+
+        it "averages all values when fewer than window" $ do
+            applyFold
+                (averageOverWindow 10)
+                [2.0, 4.0, 6.0 :: Double]
+                `shouldBe` 4.0
+
+        it "averages only the last window values" $ do
+            applyFold
+                (averageOverWindow 3)
+                [1.0, 2.0, 3.0, 10.0, 20.0, 30.0 :: Double]
+                `shouldBe` 20.0
+
+    describe "speedoMeter" $ do
+        it "returns 0 with no input" $ do
+            applyFold (speedoMeter 10) []
+                `shouldBe` 0
+
+        it "returns 0 before first window completes" $ do
+            applyFold (speedoMeter 100) (timestamps 50)
+                `shouldBe` 0
+
+        it
+            "measures ~1 event/sec with 1-second intervals"
+            $ do
+                let speed =
+                        applyFold
+                            (speedoMeter 10)
+                            (timestamps 25)
+                speed `shouldSatisfy` (> 0)
+
+    describe "valueSpeedoMeter" $ do
+        it "returns 0 with no input" $ do
+            applyFold (valueSpeedoMeter 10) []
+                `shouldBe` 0
+
+        it "measures value change rate" $ do
+            let events =
+                    zip
+                        (timestamps 25)
+                        [0, 10 .. 240]
+                speed =
+                    applyFold
+                        (valueSpeedoMeter 10)
+                        events
+            speed `shouldSatisfy` (> 0)

--- a/test/Data/Tracer/PrometheusSpec.hs
+++ b/test/Data/Tracer/PrometheusSpec.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Data.Tracer.PrometheusSpec (spec) where
+
+import qualified Data.Text as Text
+import Data.Tracer.Prometheus
+    ( counter
+    , gauge
+    , renderPrometheusLines
+    )
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = describe "Data.Tracer.Prometheus" $ do
+    describe "gauge" $ do
+        it "renders HELP, TYPE, and value lines" $ do
+            gauge "myapp" "queue_len" "Queue length" 42.5
+                `shouldBe` [ "# HELP myapp_queue_len"
+                                <> " Queue length"
+                           , "# TYPE myapp_queue_len"
+                                <> " gauge"
+                           , "myapp_queue_len 42.5"
+                           ]
+
+        it "renders integer-like doubles without .0" $ do
+            let lines =
+                    gauge
+                        "myapp"
+                        "count"
+                        "Count"
+                        3.0
+            last lines `shouldBe` "myapp_count 3"
+
+    describe "counter" $ do
+        it "renders with counter type" $ do
+            let lines =
+                    counter
+                        "myapp"
+                        "total"
+                        "Total"
+                        100.0
+            lines
+                !! 1
+                `shouldBe` "# TYPE myapp_total counter"
+
+    describe "renderPrometheusLines" $ do
+        it "concatenates metric blocks" $ do
+            let result =
+                    renderPrometheusLines
+                        [ gauge
+                            "app"
+                            "a"
+                            "Metric A"
+                            1.0
+                        , counter
+                            "app"
+                            "b"
+                            "Metric B"
+                            2.0
+                        ]
+            Text.count "\n" result `shouldBe` 6
+            Text.isInfixOf "app_a 1" result
+                `shouldBe` True
+            Text.isInfixOf "app_b 2" result
+                `shouldBe` True


### PR DESCRIPTION
## Summary
- Add `Data.Tracer.Foldl.Extra` with generic fold utilities (`speedoMeter`, `valueSpeedoMeter`, `averageOverWindow`) for metrics collection over event streams
- Add `Data.Tracer.Prometheus` with Prometheus text exposition format helpers (`gauge`, `counter`, `renderPrometheusLines`)

Extracted from cardano-utxo-csmt to enable reuse by mpfs-serve and future services.

Closes #19

## Test plan
- [x] New test suites for both modules
- [x] All 67 tests pass
- [x] `just CI` passes (build, test, cabal check, fourmolu, hlint)